### PR TITLE
Gap in size of the border width

### DIFF
--- a/jquery.connections.js
+++ b/jquery.connections.js
@@ -189,7 +189,7 @@
 			data.css.left = connection.offsetLeft + l - current_rect.left;
 			data.css.top = connection.offsetTop + t - current_rect.top;
 			data.css.width = width - border_w;
-			data.css.height = height - border_h;
+			data.css.height = height - border_h + border_w;
 		}
 		var bc = data.borderClasses;
 		$(connection).


### PR DESCRIPTION
This fix the gap between the `from` element and `connection` box in size of the border-width of `connection` element.

Problem:
![Problem Screenshot](https://user-images.githubusercontent.com/1992754/45449784-7f3af300-b6ac-11e8-906d-8d5a96a987bd.jpg)

Fix:
![Fix Screenshot](https://user-images.githubusercontent.com/1992754/45449938-04260c80-b6ad-11e8-9bdf-18e133944ffc.jpg)
